### PR TITLE
refactor: restore selector extraction pattern for EditorView

### DIFF
--- a/src/editor/hooks/useExitingNodes.ts
+++ b/src/editor/hooks/useExitingNodes.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from "react";
+import type { NodePosition } from "../layout";
+import type { Node, NodeId } from "../types";
+
+type ExitingNode = { node: Node; pos: NodePosition };
+
+export function useExitingNodes(docNodes: Record<NodeId, Node>, positions: Record<NodeId, NodePosition>) {
+  const prevNodesRef = useRef<Record<NodeId, Node> | null>(null);
+  const prevPositionsRef = useRef<Record<NodeId, NodePosition> | null>(null);
+  const timeoutIdsRef = useRef<number[]>([]);
+  const [exitingNodes, setExitingNodes] = useState<Record<NodeId, ExitingNode>>({});
+
+  useEffect(() => {
+    const prevNodes = prevNodesRef.current;
+    const prevPositions = prevPositionsRef.current;
+    if (prevNodes && prevPositions) {
+      const currentIds = new Set(Object.keys(docNodes));
+      const removed: NodeId[] = [];
+      for (const id of Object.keys(prevNodes)) {
+        if (!currentIds.has(id)) removed.push(id);
+      }
+
+      if (removed.length > 0) {
+        setExitingNodes((current) => {
+          const next: Record<NodeId, ExitingNode> = { ...current };
+          for (const id of removed) {
+            const node = prevNodes[id];
+            const pos = prevPositions[id];
+            if (!node || !pos) continue;
+            next[id] = { node, pos };
+            const timeoutId = window.setTimeout(() => {
+              setExitingNodes((latest) => {
+                if (!latest[id]) return latest;
+                const { [id]: _, ...rest } = latest;
+                return rest;
+              });
+            }, 180);
+            timeoutIdsRef.current.push(timeoutId);
+          }
+          return next;
+        });
+      }
+    }
+
+    prevNodesRef.current = docNodes;
+    prevPositionsRef.current = positions;
+
+    setExitingNodes((current) => {
+      const next: Record<NodeId, ExitingNode> = {};
+      for (const [id, entry] of Object.entries(current)) {
+        if (!docNodes[id]) next[id] = entry;
+      }
+      return next;
+    });
+  }, [docNodes, positions]);
+
+  useEffect(() => {
+    return () => {
+      for (const id of timeoutIdsRef.current) {
+        window.clearTimeout(id);
+      }
+      timeoutIdsRef.current = [];
+    };
+  }, []);
+
+  return exitingNodes;
+}

--- a/src/editor/selectors.ts
+++ b/src/editor/selectors.ts
@@ -1,0 +1,49 @@
+import type { Document, Node, NodeId } from "./types";
+import type { NodePosition } from "./layout";
+
+export function buildNodeEntries(doc: Document, positions: Record<NodeId, NodePosition>) {
+  const entries: { node: Node; pos: NodePosition | undefined }[] = Object.values(doc.nodes).map(
+    (node) => ({ node, pos: positions[node.id] }),
+  );
+
+  return entries
+    .filter((entry): entry is { node: Node; pos: NodePosition } => entry.pos !== undefined)
+    .sort((a, b) => {
+      if (a.pos.depth !== b.pos.depth) return a.pos.depth - b.pos.depth;
+      return a.pos.y - b.pos.y;
+    });
+}
+
+export function buildEdges(doc: Document): { fromId: NodeId; toId: NodeId }[] {
+  const list: { fromId: NodeId; toId: NodeId }[] = [];
+  for (const node of Object.values(doc.nodes)) {
+    for (const childId of node.childrenIds) {
+      list.push({ fromId: node.id, toId: childId });
+    }
+  }
+  return list;
+}
+
+export function buildHighlightedEdgeKeys(
+  doc: Document,
+  edges: { fromId: NodeId; toId: NodeId }[],
+): Set<string> {
+  const set = new Set<string>();
+
+  const cursor = doc.nodes[doc.cursorId];
+  if (!cursor) return set;
+
+  let current: Node | undefined = cursor;
+  while (current?.parentId) {
+    set.add(`${current.parentId}-${current.id}`);
+    current = doc.nodes[current.parentId];
+  }
+
+  for (const edge of edges) {
+    if (edge.fromId === doc.cursorId || edge.toId === doc.cursorId) {
+      set.add(`${edge.fromId}-${edge.toId}`);
+    }
+  }
+
+  return set;
+}

--- a/src/features/keyboard/handlers.ts
+++ b/src/features/keyboard/handlers.ts
@@ -1,0 +1,322 @@
+import type { EditorAction } from "../../editor/state";
+import type { Mode, NodeColor } from "../../editor/types";
+
+type Dispatch = (action: EditorAction) => void;
+
+type ModalStateParams = {
+  event: KeyboardEvent;
+  helpOpen: boolean;
+  searchOpen: boolean;
+  paletteOpen: boolean;
+  nodeColorOpen: boolean;
+  closeConfirmDocId: string | null;
+  colorShortcuts: Record<string, NodeColor>;
+  dispatch: Dispatch;
+  setHelpOpen: (open: boolean) => void;
+  setSearchOpen: (open: boolean) => void;
+  setPaletteOpen: (open: boolean) => void;
+  setNodeColorOpen: (open: boolean) => void;
+};
+
+type InsertModeParams = {
+  event: KeyboardEvent;
+  dispatch: Dispatch;
+  resetPendingDelete: () => void;
+};
+
+type NormalModeParams = {
+  event: KeyboardEvent;
+  dispatch: Dispatch;
+  openJump: () => void;
+  openNodeColor: () => void;
+  consumeDeleteChord: (event: KeyboardEvent) => boolean;
+};
+
+type GlobalModeParams = {
+  event: KeyboardEvent;
+  mode: Mode;
+  setHelpOpen: (open: boolean) => void;
+  setSearchOpen: (open: boolean) => void;
+  setPaletteOpen: (open: boolean) => void;
+  setPaletteQuery: (query: string) => void;
+  setPaletteIndex: (index: number) => void;
+};
+
+export function shouldPreventModalCtrlCombos(event: KeyboardEvent): boolean {
+  return event.ctrlKey && (event.key === "w" || event.key === "t" || event.key === "Tab");
+}
+
+export function handleModalStateKeys(params: ModalStateParams): boolean {
+  const {
+    event,
+    helpOpen,
+    searchOpen,
+    paletteOpen,
+    nodeColorOpen,
+    closeConfirmDocId,
+    colorShortcuts,
+    dispatch,
+    setHelpOpen,
+    setSearchOpen,
+    setPaletteOpen,
+    setNodeColorOpen,
+  } = params;
+
+  if (helpOpen) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setHelpOpen(false);
+      return true;
+    }
+    event.preventDefault();
+    return true;
+  }
+
+  if (searchOpen) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setSearchOpen(false);
+      return true;
+    }
+    if (shouldPreventModalCtrlCombos(event)) {
+      event.preventDefault();
+    }
+    return true;
+  }
+
+  if (paletteOpen) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setPaletteOpen(false);
+      return true;
+    }
+    if (shouldPreventModalCtrlCombos(event)) {
+      event.preventDefault();
+    }
+    return true;
+  }
+
+  if (nodeColorOpen) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setNodeColorOpen(false);
+      return true;
+    }
+
+    if (event.key === "0") {
+      event.preventDefault();
+      dispatch({ type: "setCursorColor", color: null });
+      setNodeColorOpen(false);
+      return true;
+    }
+
+    const color = colorShortcuts[event.key];
+    if (color) {
+      event.preventDefault();
+      dispatch({ type: "setCursorColor", color });
+      setNodeColorOpen(false);
+      return true;
+    }
+
+    event.preventDefault();
+    return true;
+  }
+
+  if (closeConfirmDocId) {
+    const key = event.key;
+    if (key === "y" || key === "Y") {
+      event.preventDefault();
+      dispatch({ type: "closeActiveDoc" });
+      return true;
+    }
+    if (key === "n" || key === "N" || key === "Escape") {
+      event.preventDefault();
+      dispatch({ type: "cancelCloseConfirm" });
+      return true;
+    }
+    event.preventDefault();
+    return true;
+  }
+
+  return false;
+}
+
+export function handleGlobalModeKeys(params: GlobalModeParams): boolean {
+  const {
+    event,
+    mode,
+    setHelpOpen,
+    setSearchOpen,
+    setPaletteOpen,
+    setPaletteQuery,
+    setPaletteIndex,
+  } = params;
+
+  if (mode === "normal" && (event.key === "?" || (event.key === "/" && event.shiftKey))) {
+    event.preventDefault();
+    setHelpOpen(true);
+    return true;
+  }
+
+  if (mode === "normal" && event.ctrlKey && (event.key === "f" || event.key === "F")) {
+    event.preventDefault();
+    setSearchOpen(true);
+    setPaletteOpen(false);
+    return true;
+  }
+
+  if (mode === "normal" && event.ctrlKey && (event.key === "p" || event.key === "P")) {
+    event.preventDefault();
+    setPaletteQuery("");
+    setPaletteIndex(0);
+    setPaletteOpen(true);
+    setSearchOpen(false);
+    return true;
+  }
+
+  return false;
+}
+
+export function handleInsertModeKeys({ event, dispatch, resetPendingDelete }: InsertModeParams): boolean {
+  resetPendingDelete();
+
+  if (event.key === "Escape") {
+    event.preventDefault();
+    dispatch({ type: "commitInsert" });
+    return true;
+  }
+  if (event.key === "Tab" || (event.ctrlKey && event.key === "Tab")) {
+    event.preventDefault();
+    return true;
+  }
+  if (event.ctrlKey && (event.key === "t" || event.key === "w")) {
+    event.preventDefault();
+    return true;
+  }
+
+  return true;
+}
+
+export function handleNormalModeKeys({
+  event,
+  dispatch,
+  openJump,
+  openNodeColor,
+  consumeDeleteChord,
+}: NormalModeParams): boolean {
+  if (consumeDeleteChord(event)) {
+    dispatch({ type: "deleteNode" });
+    return true;
+  }
+
+  if (!event.ctrlKey && !event.metaKey && !event.altKey && event.key === "c") {
+    event.preventDefault();
+    openNodeColor();
+    return true;
+  }
+
+  if (event.ctrlKey && (event.key === "t" || event.key === "T")) {
+    event.preventDefault();
+    dispatch({ type: "createDoc" });
+    return true;
+  }
+  if (event.ctrlKey && (event.key === "w" || event.key === "W")) {
+    event.preventDefault();
+    dispatch({ type: "requestCloseActiveDoc" });
+    return true;
+  }
+
+  if (event.ctrlKey && event.key === "Tab") {
+    event.preventDefault();
+    if (event.shiftKey) {
+      dispatch({ type: "switchDocPrev" });
+    } else {
+      dispatch({ type: "switchDocNext" });
+    }
+    return true;
+  }
+
+  if (event.key === "Tab") {
+    event.preventDefault();
+    dispatch({ type: "addChildAndInsert" });
+    return true;
+  }
+
+  if (event.key === "Enter") {
+    event.preventDefault();
+    dispatch({ type: "addSiblingAndInsert" });
+    return true;
+  }
+
+  if (event.key === "Escape") {
+    event.preventDefault();
+    dispatch({ type: "commitInsert" });
+    return true;
+  }
+
+  if (!event.ctrlKey && !event.metaKey && !event.altKey && event.key.toLowerCase() === "f") {
+    event.preventDefault();
+    openJump();
+    return true;
+  }
+
+  if (event.key === "i") {
+    event.preventDefault();
+    dispatch({ type: "enterInsert" });
+    return true;
+  }
+
+  if (event.key === "h") {
+    event.preventDefault();
+    dispatch({ type: "moveCursor", direction: "parent" });
+    return true;
+  }
+  if (event.key === "l") {
+    event.preventDefault();
+    dispatch({ type: "moveCursor", direction: "child" });
+    return true;
+  }
+  if (event.key === "j") {
+    event.preventDefault();
+    dispatch({ type: "moveCursor", direction: "nextSibling" });
+    return true;
+  }
+  if (event.key === "k") {
+    event.preventDefault();
+    dispatch({ type: "moveCursor", direction: "prevSibling" });
+    return true;
+  }
+  if (event.key === "J") {
+    event.preventDefault();
+    dispatch({ type: "swapSibling", direction: "down" });
+    return true;
+  }
+  if (event.key === "K") {
+    event.preventDefault();
+    dispatch({ type: "swapSibling", direction: "up" });
+    return true;
+  }
+  if (event.key === "H") {
+    event.preventDefault();
+    dispatch({ type: "reparentNode", direction: "left" });
+    return true;
+  }
+  if (event.key === "L") {
+    event.preventDefault();
+    dispatch({ type: "reparentNode", direction: "right" });
+    return true;
+  }
+
+  if (event.key === "u") {
+    event.preventDefault();
+    dispatch({ type: "undo" });
+    return true;
+  }
+  if (event.ctrlKey && event.key === "r") {
+    event.preventDefault();
+    dispatch({ type: "redo" });
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
### Motivation
- EditorView に埋め込まれていた派生計算ロジックを selector パターンへ戻し、描画ロジック・副作用フック・派生計算の責務を明確にするための整理です。 
- キーボード処理をハンドラ群へ分離して `App.tsx` 側のキー分岐を簡潔にし、`dd` 削除チャード等のタイマー管理を明確化するためです。 
- reducer 側のモードガードと保存リビジョン更新の重複を削減して可読性と保守性を高めるためです。

### Description
- `src/editor/selectors.ts` を復活させ `buildNodeEntries` / `buildEdges` / `buildHighlightedEdgeKeys` を移し、`EditorView.tsx` はこれらを import して利用するように戻しました。 
- 削除ノードの退出アニメーションロジックを `src/editor/hooks/useExitingNodes.ts` に切り出してタイマーやクリーンアップをフックで管理するようにしました。 
- キーボード関連ロジックを `src/features/keyboard/handlers.ts` にまとめ、`App.tsx` 側は `handleModalStateKeys` / `handleGlobalModeKeys` / `handleInsertModeKeys` / `handleNormalModeKeys` を呼ぶ構成に変更し、`resetPendingDelete` / `consumeDeleteChord` を導入しました。 
- `src/editor/state.ts` に `applyInNormalMode` と `applyDocMutation` を追加してモードチェックと `saveRevision` 増分処理の重複を削減しました。 
- 変更はコミット `429e2c1` にて適用しています。

### Testing
- ビルド検証として `npm run build` を実行し成功しました。 
- `git status --short` と `git log --oneline -3` を確認し、該当コミットが作成されていることを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dea0a8db4832a9b53c97d39be90a9)