### PR TITLE
fix: prevent connector overlap when adding siblings / 兄弟追加時の接続線重複を防止

### DIFF
--- a/src/editor/domain/freeLayout.ts
+++ b/src/editor/domain/freeLayout.ts
@@ -36,6 +36,170 @@ export function moveNodePositions(
   return next;
 }
 
+const COLLISION_GAP_X = 16;
+const COLLISION_GAP_Y = 12;
+
+type NodeRect = CanvasPoint & NodeSize;
+
+function rectanglesOverlap(a: NodeRect, b: NodeRect): boolean {
+  return (
+    a.x < b.x + b.width + COLLISION_GAP_X &&
+    a.x + a.width + COLLISION_GAP_X > b.x &&
+    a.y < b.y + b.height + COLLISION_GAP_Y &&
+    a.y + a.height + COLLISION_GAP_Y > b.y
+  );
+}
+
+function findMovableBranchRoot(
+  doc: DocumentState,
+  nodeId: NodeId,
+  protectedIds: ReadonlySet<NodeId>,
+): NodeId | null {
+  if (protectedIds.has(nodeId)) return null;
+  let currentId = nodeId;
+  const visited = new Set<NodeId>();
+  while (!visited.has(currentId)) {
+    visited.add(currentId);
+    const parentId = doc.nodes[currentId]?.parentId;
+    if (!parentId || protectedIds.has(parentId) || !doc.nodes[parentId]) {
+      return currentId;
+    }
+    currentId = parentId;
+    if (protectedIds.has(currentId)) return null;
+  }
+  return null;
+}
+
+export function makeSpaceForNode(
+  doc: DocumentState,
+  preferred: CanvasPoint,
+  sizes: Record<NodeId, NodeSize>,
+  candidateSize: NodeSize,
+  protectedNodeIds: readonly NodeId[],
+): Record<NodeId, CanvasPoint> {
+  let positions = { ...doc.nodePositions };
+  const protectedIds = new Set(protectedNodeIds);
+  const candidateRect = { ...preferred, ...candidateSize };
+  const branchRootFor = (nodeId: NodeId) =>
+    findMovableBranchRoot(doc, nodeId, protectedIds);
+  const branchIdsFor = (rootId: NodeId) => collectSubtreeNodeIds(doc, rootId);
+  const rectFor = (nodeId: NodeId): NodeRect | null => {
+    const point = positions[nodeId];
+    if (!point) return null;
+    return {
+      ...point,
+      ...(sizes[nodeId] ?? { width: NODE_WIDTH, height: NODE_HEIGHT }),
+    };
+  };
+  const branchTop = (rootId: NodeId) =>
+    Math.min(
+      ...branchIdsFor(rootId)
+        .map((id) => positions[id]?.y)
+        .filter((value): value is number => value !== undefined),
+    );
+
+  const pushBranchBelow = (
+    rootId: NodeId,
+    blockers: readonly NodeRect[],
+    activeRoots: ReadonlySet<NodeId>,
+  ) => {
+    if (activeRoots.has(rootId)) return;
+    const nextActiveRoots = new Set(activeRoots).add(rootId);
+    const branchIds = branchIdsFor(rootId);
+    const branchSet = new Set(branchIds);
+    let currentBlockers = [...blockers];
+
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      let dy = 0;
+      for (const nodeId of branchIds) {
+        const rect = rectFor(nodeId);
+        if (!rect) continue;
+        for (const blocker of currentBlockers) {
+          if (!rectanglesOverlap(rect, blocker)) continue;
+          dy = Math.max(dy, blocker.y + blocker.height + COLLISION_GAP_Y - rect.y);
+        }
+      }
+      if (dy > 0) {
+        positions = moveNodePositions(positions, branchIds, 0, dy);
+      }
+
+      const collisions = Object.keys(positions)
+        .filter((nodeId) => !branchSet.has(nodeId))
+        .map((nodeId) => {
+          const rect = rectFor(nodeId);
+          if (!rect) return null;
+          const overlaps = branchIds.some((branchId) => {
+            const branchRect = rectFor(branchId);
+            return branchRect ? rectanglesOverlap(branchRect, rect) : false;
+          });
+          return overlaps ? { nodeId, rect } : null;
+        })
+        .filter(
+          (collision): collision is { nodeId: NodeId; rect: NodeRect } =>
+            collision !== null,
+        )
+        .sort(
+          (a, b) =>
+            a.rect.y - b.rect.y ||
+            a.rect.x - b.rect.x ||
+            a.nodeId.localeCompare(b.nodeId),
+        );
+
+      if (collisions.length === 0) return;
+      let addedBlocker = false;
+      for (const collision of collisions) {
+        const otherRoot = branchRootFor(collision.nodeId);
+        if (
+          !otherRoot ||
+          activeRoots.has(otherRoot) ||
+          branchTop(otherRoot) < branchTop(rootId)
+        ) {
+          currentBlockers.push(collision.rect);
+          addedBlocker = true;
+          continue;
+        }
+        const branchRects = branchIds
+          .map(rectFor)
+          .filter((rect): rect is NodeRect => rect !== null);
+        pushBranchBelow(otherRoot, branchRects, nextActiveRoots);
+      }
+      if (!addedBlocker) {
+        const stillOverlaps = collisions.some(({ nodeId }) => {
+          const rect = rectFor(nodeId);
+          return (
+            rect !== null &&
+            branchIds.some((branchId) => {
+              const branchRect = rectFor(branchId);
+              return branchRect ? rectanglesOverlap(branchRect, rect) : false;
+            })
+          );
+        });
+        if (!stillOverlaps) return;
+      }
+    }
+  };
+
+  const initialRoots = Object.keys(positions)
+    .filter((nodeId) => {
+      const rect = rectFor(nodeId);
+      return rect ? rectanglesOverlap(candidateRect, rect) : false;
+    })
+    .map(branchRootFor)
+    .filter((rootId): rootId is NodeId => rootId !== null)
+    .filter((rootId, index, roots) => roots.indexOf(rootId) === index)
+    .sort(
+      (a, b) =>
+        branchTop(a) - branchTop(b) ||
+        (positions[a]?.x ?? 0) - (positions[b]?.x ?? 0) ||
+        a.localeCompare(b),
+    );
+
+  for (const rootId of initialRoots) {
+    pushBranchBelow(rootId, [candidateRect], new Set());
+  }
+  return positions;
+}
+
 export function autoLayoutBranch(
   doc: DocumentState,
   rootId: NodeId,
@@ -66,10 +230,10 @@ function overlapsAny(
     if (id === ignoredId) return false;
     const otherSize = sizes[id] ?? { width: NODE_WIDTH, height: NODE_HEIGHT };
     return (
-      point.x < other.x + otherSize.width + 16 &&
-      point.x + candidateSize.width + 16 > other.x &&
-      point.y < other.y + otherSize.height + 12 &&
-      point.y + candidateSize.height + 12 > other.y
+      point.x < other.x + otherSize.width + COLLISION_GAP_X &&
+      point.x + candidateSize.width + COLLISION_GAP_X > other.x &&
+      point.y < other.y + otherSize.height + COLLISION_GAP_Y &&
+      point.y + candidateSize.height + COLLISION_GAP_Y > other.y
     );
   });
 }

--- a/src/editor/domain/treeOps.ts
+++ b/src/editor/domain/treeOps.ts
@@ -1,6 +1,6 @@
 import type { Document, Node, NodeId } from "../types";
 import { getNodeSize, getNodeSizes, H_GAP, V_GAP } from "../layout";
-import { findAvailablePosition } from "./freeLayout";
+import { findAvailablePosition, makeSpaceForNode } from "./freeLayout";
 import { generateId } from "./id";
 
 export function moveCursor(
@@ -173,18 +173,29 @@ export function addSibling(doc: Document): { updated: Document; newNodeId: NodeI
   const sizes = getNodeSizes(doc.nodes);
   const cursorSize = sizes[cursor.id] ?? getNodeSize(cursor);
   const newNodeSize = getNodeSize(newNode);
-  const point = findAvailablePosition(
-    { x: cursorPoint.x, y: cursorPoint.y + cursorSize.height + V_GAP },
-    currentPositions,
+  const point = {
+    x: cursorPoint.x,
+    y: cursorPoint.y + cursorSize.height + V_GAP,
+  };
+  const protectedNodeIds: NodeId[] = [];
+  let protectedId: NodeId | null = cursor.id;
+  while (protectedId) {
+    protectedNodeIds.push(protectedId);
+    protectedId = doc.nodes[protectedId]?.parentId ?? null;
+  }
+  const nextPositions = makeSpaceForNode(
+    doc,
+    point,
     sizes,
     newNodeSize,
+    protectedNodeIds,
   );
 
   return {
     updated: {
       ...doc,
       cursorId: newId,
-      nodePositions: { ...currentPositions, [newId]: point },
+      nodePositions: { ...nextPositions, [newId]: point },
       nodes: {
         ...doc.nodes,
         [newId]: newNode,

--- a/tests/offline/freeLayout.test.cjs
+++ b/tests/offline/freeLayout.test.cjs
@@ -4,6 +4,7 @@ const {
   autoLayoutBranch,
   computeSnapAdjustment,
   findAvailablePosition,
+  makeSpaceForNode,
   moveNodePositions,
 } = require("../../.tmp-tests/src/editor/domain/freeLayout.js");
 const {
@@ -189,4 +190,63 @@ test("moving, collision avoidance, and alignment snapping are deterministic", ()
   );
   assert.deepEqual({ dx: snap.dx, dy: snap.dy }, { dx: 2, dy: 2 });
   assert.equal(snap.guides.length, 2);
+});
+
+test("makeSpaceForNode moves a colliding branch with its descendants", () => {
+  const doc = makeDoc();
+  doc.nodePositions = {
+    root: { x: 0, y: 0 },
+    a: { x: 260, y: 0 },
+    a1: { x: 520, y: 0 },
+    b: { x: 260, y: 50 },
+  };
+  const sizes = {
+    root: { width: 180, height: 34 },
+    a: { width: 180, height: 34 },
+    a1: { width: 180, height: 34 },
+    b: { width: 320, height: 34 },
+  };
+  const next = makeSpaceForNode(
+    doc,
+    { x: 260, y: 50 },
+    sizes,
+    { width: 180, height: 34 },
+    ["root", "a"],
+  );
+
+  assert.deepEqual(next.root, doc.nodePositions.root);
+  assert.deepEqual(next.a, doc.nodePositions.a);
+  assert.deepEqual(next.a1, doc.nodePositions.a1);
+  assert.deepEqual(next.b, { x: 260, y: 96 });
+});
+
+test("makeSpaceForNode cascades displacement into a lower branch", () => {
+  const doc = makeDoc();
+  doc.nodes.b.childrenIds = ["b1"];
+  doc.nodes.b1 = { id: "b1", text: "b1", parentId: "b", childrenIds: [] };
+  doc.nodes.c = { id: "c", text: "c", parentId: "root", childrenIds: [] };
+  doc.nodes.root.childrenIds.push("c");
+  doc.nodePositions = {
+    root: { x: 0, y: 0 },
+    a: { x: 260, y: 0 },
+    a1: { x: 520, y: 0 },
+    b: { x: 260, y: 50 },
+    b1: { x: 520, y: 50 },
+    c: { x: 260, y: 100 },
+  };
+  const sizes = Object.fromEntries(
+    Object.keys(doc.nodes).map((id) => [id, { width: 180, height: 34 }]),
+  );
+  const next = makeSpaceForNode(
+    doc,
+    { x: 260, y: 50 },
+    sizes,
+    { width: 180, height: 34 },
+    ["root", "a"],
+  );
+
+  assert.equal(next.b.y, 96);
+  assert.equal(next.b1.y, 96);
+  assert.equal(next.c.y, 142);
+  assert.deepEqual(next.root, doc.nodePositions.root);
 });

--- a/tests/offline/treeOps.test.cjs
+++ b/tests/offline/treeOps.test.cjs
@@ -65,3 +65,26 @@ test("addSibling: root cursor falls back to addChild", () => {
   assert.equal(updated.nodes[newNodeId].parentId, "root");
   assert.equal(updated.nodes.root.childrenIds.includes(newNodeId), true);
 });
+
+test("addSibling keeps the preferred position and moves an overlapping lower branch", () => {
+  const doc = {
+    ...makeDoc(),
+    cursorId: "a1",
+    nodePositions: {
+      root: { x: 0, y: 0 },
+      a: { x: 260, y: 0 },
+      a1: { x: 520, y: 0 },
+      b: { x: 260, y: 50 },
+    },
+  };
+  doc.nodes.b.text = "横幅の大きいノード".repeat(10);
+
+  const updated = addSibling(doc).updated;
+  const newNodeId = updated.cursorId;
+
+  assert.deepEqual(updated.nodePositions[newNodeId], { x: 520, y: 50 });
+  assert.equal(updated.nodePositions.b.y > 50, true);
+  assert.deepEqual(updated.nodePositions.root, doc.nodePositions.root);
+  assert.deepEqual(updated.nodePositions.a, doc.nodePositions.a);
+  assert.deepEqual(updated.nodePositions.a1, doc.nodePositions.a1);
+});


### PR DESCRIPTION
## Summary / 概要
- Keep newly added siblings at their intended position. / 新規兄弟を本来の位置に配置します。
- Move overlapping lower branches, including descendants, downward. / 重複する下側ブランチを子孫ごと下へ移動します。
- Resolve chained collisions deterministically. / 連鎖する衝突を決定的に解消します。

## Verification / 検証
- `npm run test:offline` (96 passed)
- `npm run build`
- Reproduced Issue #35 in the local app and confirmed connectors no longer cross the wide node. / ローカルアプリでIssue #35を再現し、接続線が横幅の大きいノードを横切らないことを確認しました。

Closes #35