### PR TITLE
[codex] Fix initial root node position / 初期表示のルートノード位置を修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -935,6 +935,7 @@ function App() {
           zoom={zoomPan.zoom}
           viewportRef={viewportRef}
           panGestureActive={zoomPan.panGestureActive}
+          viewSessionKey={`${state.workspace.activeDocId}:${visibleProjection.state.rootId}`}
           highlightedNodeIds={highlightedNodeIds}
           activeHighlightedNodeId={activeSearchNodeId}
           jumpHints={jumpSession?.nodeToHint ?? null}

--- a/src/editor/EditorView.tsx
+++ b/src/editor/EditorView.tsx
@@ -6,7 +6,11 @@ import {
 } from "./domain/editorEnter";
 import type { EditorEnterEvent } from "./domain/editorEnter";
 import { collectSubtreeNodeIds, computeSnapAdjustment, moveNodePositions } from "./domain/freeLayout";
-import { computeCenteredScrollFromRects } from "./domain/viewport";
+import {
+  computeInitialScrollForRoot,
+  isUsableViewportSize,
+  shouldResetViewportSession,
+} from "./domain/viewport";
 import type { AnchorSide, CanvasPoint, DocumentState, Mode, Node, NodeId } from "./types";
 import "./EditorView.scss";
 import {
@@ -24,6 +28,7 @@ type Props = {
   zoom: number;
   viewportRef: React.RefObject<HTMLDivElement | null>;
   panGestureActive: boolean;
+  viewSessionKey: string;
   highlightedNodeIds: Set<NodeId> | null;
   activeHighlightedNodeId: NodeId | null;
   jumpHints: Record<NodeId, string> | null;
@@ -66,6 +71,7 @@ type DragPreview = {
 };
 
 type SelectionRect = { x: number; y: number; width: number; height: number };
+const REQUIRED_STABLE_VIEWPORT_FRAMES = 2;
 
 function getJumpHintState(
   jumpHints: Record<NodeId, string> | null,
@@ -88,6 +94,7 @@ export function EditorView({
   zoom,
   viewportRef,
   panGestureActive,
+  viewSessionKey,
   highlightedNodeIds,
   activeHighlightedNodeId,
   jumpHints,
@@ -133,6 +140,9 @@ export function EditorView({
   const initialViewPositionedRef = useRef(false);
   const initialCursorIdRef = useRef<NodeId | null>(null);
   const initialCenterFrameRef = useRef<number | null>(null);
+  const previousViewSessionKeyRef = useRef<string | null>(null);
+  const stableViewportFramesRef = useRef(0);
+  const previousViewportSizeRef = useRef<{ width: number; height: number } | null>(null);
   const [exitingNodes, setExitingNodes] = useState<Record<NodeId, ExitingNode>>({});
   const interactionDisabled = disabled || mode === "insert" || panGestureActive;
 
@@ -140,54 +150,101 @@ export function EditorView({
   const cursorNode = doc.nodes[doc.cursorId];
 
   useLayoutEffect(() => {
+    if (!shouldResetViewportSession(previousViewSessionKeyRef.current, viewSessionKey)) {
+      previousViewSessionKeyRef.current = viewSessionKey;
+      return;
+    }
+
+    if (initialCenterFrameRef.current !== null) {
+      cancelAnimationFrame(initialCenterFrameRef.current);
+      initialCenterFrameRef.current = null;
+    }
+    initialViewPositionedRef.current = false;
+    initialCursorIdRef.current = null;
+    stableViewportFramesRef.current = 0;
+    previousViewportSizeRef.current = null;
+    previousViewSessionKeyRef.current = viewSessionKey;
+  }, [viewSessionKey]);
+
+  useLayoutEffect(() => {
     if (initialViewPositionedRef.current) return;
     const viewport = viewportRef.current;
-    if (!viewport || !layout.positions[doc.rootId]) return;
+    const rootPoint = layout.positions[doc.rootId];
+    const rootSize = layout.sizes[doc.rootId];
+    if (!viewport || !rootPoint || !rootSize) return;
     initialCursorIdRef.current = doc.cursorId;
+    let disposed = false;
 
-    const centerRoot = () => {
-      const rootElement = [
-        ...(canvasRef.current?.querySelectorAll<HTMLElement>("[data-node-id]") ?? []),
-      ].find((element) => element.dataset.nodeId === doc.rootId);
-      if (!rootElement) return;
-      const viewportRect = viewport.getBoundingClientRect();
-      const rootRect = rootElement.getBoundingClientRect();
-      const scroll = computeCenteredScrollFromRects(
-        { x: viewport.scrollLeft, y: viewport.scrollTop },
-        {
-          left: rootRect.left,
-          top: rootRect.top,
-          width: rootRect.width,
-          height: rootRect.height,
-        },
-        {
-          left: viewportRect.left,
-          top: viewportRect.top,
-          width: viewportRect.width,
-          height: viewportRect.height,
-        },
+    const scheduleAlignment = () => {
+      if (disposed || initialCenterFrameRef.current !== null) return;
+      initialCenterFrameRef.current = requestAnimationFrame(alignRootForOpen);
+    };
+
+    const alignRootForOpen = () => {
+      initialCenterFrameRef.current = null;
+      if (disposed) return;
+
+      const viewportSize = {
+        width: viewport.clientWidth,
+        height: viewport.clientHeight,
+      };
+      if (!isUsableViewportSize(viewportSize)) {
+        stableViewportFramesRef.current = 0;
+        scheduleAlignment();
+        return;
+      }
+
+      const previousSize = previousViewportSizeRef.current;
+      const sizeIsStable =
+        previousSize?.width === viewportSize.width &&
+        previousSize?.height === viewportSize.height;
+      stableViewportFramesRef.current = sizeIsStable
+        ? stableViewportFramesRef.current + 1
+        : 0;
+      previousViewportSizeRef.current = viewportSize;
+
+      const scroll = computeInitialScrollForRoot(
+        rootPoint,
+        rootSize,
+        viewportSize,
+        zoom,
       );
       viewport.scrollLeft = scroll.x;
       viewport.scrollTop = scroll.y;
+
+      if (stableViewportFramesRef.current >= REQUIRED_STABLE_VIEWPORT_FRAMES) {
+        initialViewPositionedRef.current = true;
+        return;
+      }
+      scheduleAlignment();
     };
 
-    centerRoot();
-    initialCenterFrameRef.current = requestAnimationFrame(() => {
-      centerRoot();
-      initialCenterFrameRef.current = requestAnimationFrame(() => {
-        centerRoot();
-        initialCenterFrameRef.current = null;
-        initialViewPositionedRef.current = true;
-      });
+    const resizeObserver = new ResizeObserver(() => {
+      if (initialViewPositionedRef.current) return;
+      stableViewportFramesRef.current = 0;
+      previousViewportSizeRef.current = null;
+      scheduleAlignment();
     });
+    resizeObserver.observe(viewport);
+    scheduleAlignment();
 
     return () => {
+      disposed = true;
+      resizeObserver.disconnect();
       if (initialCenterFrameRef.current !== null) {
         cancelAnimationFrame(initialCenterFrameRef.current);
         initialCenterFrameRef.current = null;
       }
     };
-  }, [doc.cursorId, doc.rootId, layout.positions, viewportRef, zoom]);
+  }, [
+    doc.cursorId,
+    doc.rootId,
+    layout.positions,
+    layout.sizes,
+    viewSessionKey,
+    viewportRef,
+    zoom,
+  ]);
 
   const applyEditorEnterEvent = (event: EditorEnterEvent) => {
     const result = transitionEditorEnter(editorEnterStateRef.current, event);

--- a/src/editor/domain/viewport.ts
+++ b/src/editor/domain/viewport.ts
@@ -1,4 +1,6 @@
 import type { CanvasPoint } from "../types";
+import { PADDING_X } from "../layout";
+import type { NodeSize } from "../layout";
 
 type Rect = {
   left: number;
@@ -6,6 +8,19 @@ type Rect = {
   width: number;
   height: number;
 };
+
+type ViewportSize = { width: number; height: number };
+
+export function isUsableViewportSize(viewportSize: ViewportSize): boolean {
+  return viewportSize.width > 0 && viewportSize.height > 0;
+}
+
+export function shouldResetViewportSession(
+  previousSessionKey: string | null,
+  nextSessionKey: string,
+): boolean {
+  return previousSessionKey !== null && previousSessionKey !== nextSessionKey;
+}
 
 export function computeCenteredScrollFromRects(
   currentScroll: CanvasPoint,
@@ -26,6 +41,21 @@ export function computeCenteredScrollFromRects(
         targetRect.top +
         targetRect.height / 2 -
         (viewportRect.top + viewportRect.height / 2),
+    ),
+  };
+}
+
+export function computeInitialScrollForRoot(
+  rootPoint: CanvasPoint,
+  rootSize: NodeSize,
+  viewportSize: ViewportSize,
+  zoom: number,
+): CanvasPoint {
+  return {
+    x: Math.max(0, rootPoint.x * zoom - PADDING_X),
+    y: Math.max(
+      0,
+      (rootPoint.y + rootSize.height / 2) * zoom - viewportSize.height / 2,
     ),
   };
 }

--- a/tests/offline/viewport.test.cjs
+++ b/tests/offline/viewport.test.cjs
@@ -2,7 +2,26 @@ const assert = require("node:assert/strict");
 const test = require("node:test");
 const {
   computeCenteredScrollFromRects,
+  computeInitialScrollForRoot,
+  isUsableViewportSize,
+  shouldResetViewportSession,
 } = require("../../.tmp-tests/src/editor/domain/viewport.js");
+
+test("shouldResetViewportSession resets only when the document session changes", () => {
+  assert.equal(shouldResetViewportSession(null, "doc-1"), false);
+  assert.equal(shouldResetViewportSession("doc-1", "doc-1"), false);
+  assert.equal(shouldResetViewportSession("doc-1", "doc-2"), true);
+  assert.equal(
+    shouldResetViewportSession("doc-1:root-1", "doc-1:root-2"),
+    true,
+  );
+});
+
+test("isUsableViewportSize waits for a measurable viewport", () => {
+  assert.equal(isUsableViewportSize({ width: 0, height: 600 }), false);
+  assert.equal(isUsableViewportSize({ width: 800, height: 0 }), false);
+  assert.equal(isUsableViewportSize({ width: 800, height: 600 }), true);
+});
 
 test("computeCenteredScrollFromRects centers the rendered target", () => {
   const scroll = computeCenteredScrollFromRects(
@@ -32,4 +51,26 @@ test("computeCenteredScrollFromRects does not return negative scroll positions",
   );
 
   assert.deepEqual(scroll, { x: 0, y: 0 });
+});
+
+test("computeInitialScrollForRoot places the root at left padding and vertical center", () => {
+  const scroll = computeInitialScrollForRoot(
+    { x: 100, y: 200 },
+    { width: 180, height: 34 },
+    { width: 800, height: 600 },
+    1,
+  );
+
+  assert.deepEqual(scroll, { x: 52, y: 0 });
+});
+
+test("computeInitialScrollForRoot respects zoom", () => {
+  const scroll = computeInitialScrollForRoot(
+    { x: 100, y: 200 },
+    { width: 180, height: 34 },
+    { width: 400, height: 200 },
+    2,
+  );
+
+  assert.deepEqual(scroll, { x: 152, y: 334 });
 });


### PR DESCRIPTION
## Summary
- Align the visible root node to the left padding and vertical center on initial display.
- Reinitialize the viewport when switching documents or focused roots.
- Wait for a measurable, stable viewport size to handle delayed Tauri WebView layout.

## 原因
The initial viewport adjustment could complete before the Tauri WebView had a usable final size, leaving the root node near the canvas origin at the bottom-right of the visible area.

Tauri WebView の表示領域サイズが確定する前に初期配置が完了し、ルートノードがキャンバス原点付近の右下に残る場合がありました。

## Validation
- `npm run test:offline` (100 tests passed)
- `npm run build`
- `git diff --check`

Closes #36