### PR TITLE
fix: prevent multiline node growth from overlapping lower branches / 複数行ノードの拡大で下位枝が重ならないよう修正

### DIFF
--- a/src/editor/state.ts
+++ b/src/editor/state.ts
@@ -15,6 +15,7 @@ import { cloneDocumentState, documentStateEquals } from "./domain/snapshot";
 import {
   autoLayoutBranch,
   collectSubtreeNodeIds,
+  makeSpaceForNode,
   moveNodePositions,
 } from "./domain/freeLayout";
 import {
@@ -32,7 +33,7 @@ import {
   isDescendantOrSelf,
   sanitizeCollapsedNodeIds,
 } from "./domain/visibleTree";
-import { sanitizeNodePositions } from "./layout";
+import { getNodeSize, getNodeSizes, sanitizeNodePositions } from "./layout";
 
 export type EditorAppState = {
   workspace: Workspace;
@@ -264,6 +265,16 @@ function updateDocById(
 
 function updateActiveDoc(state: EditorAppState, updater: (doc: Document) => Document): EditorAppState {
   return updateDocById(state, state.workspace.activeDocId, updater);
+}
+
+function collectProtectedNodeIds(doc: Document, nodeId: NodeId): NodeId[] {
+  const protectedIds: NodeId[] = [];
+  let currentId: NodeId | null = nodeId;
+  while (currentId) {
+    protectedIds.push(currentId);
+    currentId = doc.nodes[currentId]?.parentId ?? null;
+  }
+  return protectedIds;
 }
 
 export function editorReducer(state: EditorAppState, action: EditorAction): EditorAppState {
@@ -677,12 +688,40 @@ export function editorReducer(state: EditorAppState, action: EditorAction): Edit
       return updateActiveDoc(state, (doc) => {
         const cursor = doc.nodes[doc.cursorId];
         if (!cursor) return doc;
-        return {
+        if (cursor.text === action.text) return doc;
+        const previousSize = getNodeSize(cursor);
+        const nextCursor = { ...cursor, text: action.text };
+        const nodes = {
+          ...doc.nodes,
+          [cursor.id]: nextCursor,
+        };
+        const nextDoc = {
           ...doc,
-          nodes: {
-            ...doc.nodes,
-            [cursor.id]: { ...cursor, text: action.text },
-          },
+          nodes,
+        };
+        const nextSize = getNodeSize(nextCursor);
+        if (
+          nextSize.width <= previousSize.width &&
+          nextSize.height <= previousSize.height
+        ) {
+          return nextDoc;
+        }
+        const nodePositions = sanitizeNodePositions(doc, doc.nodePositions);
+        const preferred = nodePositions[cursor.id];
+        if (!preferred) return { ...nextDoc, nodePositions };
+        const sizes = getNodeSizes(nodes);
+        return {
+          ...nextDoc,
+          nodePositions: makeSpaceForNode(
+            {
+              ...nextDoc,
+              nodePositions,
+            },
+            preferred,
+            sizes,
+            nextSize,
+            collectProtectedNodeIds(doc, cursor.id),
+          ),
         };
       });
     }

--- a/tests/offline/state.test.cjs
+++ b/tests/offline/state.test.cjs
@@ -187,6 +187,28 @@ test("branch auto-layout keeps branch root position", () => {
   assert.equal(doc.undoStack.length, 1);
 });
 
+test("insert text growth pushes down a colliding lower branch", () => {
+  let state = withTree(makeReadyState());
+  const docId = state.workspace.activeDocId;
+
+  state = editorReducer(state, { type: "enterInsert" });
+  state = editorReducer(state, {
+    type: "setCursorText",
+    text: "line 1\nline 2\nline 3",
+  });
+
+  let doc = state.workspace.documents[docId];
+  assert.equal(state.mode, "insert");
+  assert.deepEqual(doc.nodePositions.a, { x: 260, y: 0 });
+  assert.deepEqual(doc.nodePositions.b, { x: 260, y: 86 });
+  assert.equal(doc.undoStack.length, 0);
+
+  state = editorReducer(state, { type: "commitInsert" });
+  doc = state.workspace.documents[docId];
+  assert.equal(state.mode, "normal");
+  assert.equal(doc.undoStack.length, 1);
+});
+
 test("blank-canvas child creation stores the requested position", () => {
   let state = withTree(makeReadyState());
   const docId = state.workspace.activeDocId;


### PR DESCRIPTION
## Summary
- adjust lower branches while a node grows during insert mode
- keep the edited node anchored and reuse existing collision handling
- add offline regression coverage for multiline growth overlap

## Test
- npm run test:offline
- npm run build