### PR TITLE
fix: 起動時にルートノードを左中央へ配置 / position root node at left center on startup

### DIFF
--- a/src/editor/EditorView.tsx
+++ b/src/editor/EditorView.tsx
@@ -9,6 +9,7 @@ import { collectSubtreeNodeIds, computeSnapAdjustment, moveNodePositions } from 
 import {
   computeInitialScrollForRoot,
   isUsableViewportSize,
+  shouldFollowCursor,
   shouldResetViewportSession,
 } from "./domain/viewport";
 import type { AnchorSide, CanvasPoint, DocumentState, Mode, Node, NodeId } from "./types";
@@ -71,7 +72,6 @@ type DragPreview = {
 };
 
 type SelectionRect = { x: number; y: number; width: number; height: number };
-const REQUIRED_STABLE_VIEWPORT_FRAMES = 2;
 
 function getJumpHintState(
   jumpHints: Record<NodeId, string> | null,
@@ -138,16 +138,15 @@ export function EditorView({
   const prevPositionsRef = useRef<Record<NodeId, NodePosition> | null>(null);
   const prevSizesRef = useRef<Record<NodeId, NodeSize> | null>(null);
   const initialViewPositionedRef = useRef(false);
-  const initialCursorIdRef = useRef<NodeId | null>(null);
-  const initialCenterFrameRef = useRef<number | null>(null);
+  const previousCursorIdRef = useRef<NodeId | null>(null);
   const previousViewSessionKeyRef = useRef<string | null>(null);
-  const stableViewportFramesRef = useRef(0);
-  const previousViewportSizeRef = useRef<{ width: number; height: number } | null>(null);
   const [exitingNodes, setExitingNodes] = useState<Record<NodeId, ExitingNode>>({});
   const interactionDisabled = disabled || mode === "insert" || panGestureActive;
 
   const cursorPos = layout.positions[doc.cursorId];
   const cursorNode = doc.nodes[doc.cursorId];
+  const rootPoint = layout.positions[doc.rootId];
+  const rootSize = layout.sizes[doc.rootId];
 
   useLayoutEffect(() => {
     if (!shouldResetViewportSession(previousViewSessionKeyRef.current, viewSessionKey)) {
@@ -155,92 +154,35 @@ export function EditorView({
       return;
     }
 
-    if (initialCenterFrameRef.current !== null) {
-      cancelAnimationFrame(initialCenterFrameRef.current);
-      initialCenterFrameRef.current = null;
-    }
     initialViewPositionedRef.current = false;
-    initialCursorIdRef.current = null;
-    stableViewportFramesRef.current = 0;
-    previousViewportSizeRef.current = null;
+    previousCursorIdRef.current = null;
     previousViewSessionKeyRef.current = viewSessionKey;
   }, [viewSessionKey]);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (initialViewPositionedRef.current) return;
     const viewport = viewportRef.current;
-    const rootPoint = layout.positions[doc.rootId];
-    const rootSize = layout.sizes[doc.rootId];
     if (!viewport || !rootPoint || !rootSize) return;
-    initialCursorIdRef.current = doc.cursorId;
-    let disposed = false;
-
-    const scheduleAlignment = () => {
-      if (disposed || initialCenterFrameRef.current !== null) return;
-      initialCenterFrameRef.current = requestAnimationFrame(alignRootForOpen);
+    const viewportSize = {
+      width: viewport.clientWidth,
+      height: viewport.clientHeight,
     };
+    if (!isUsableViewportSize(viewportSize)) return;
 
-    const alignRootForOpen = () => {
-      initialCenterFrameRef.current = null;
-      if (disposed) return;
-
-      const viewportSize = {
-        width: viewport.clientWidth,
-        height: viewport.clientHeight,
-      };
-      if (!isUsableViewportSize(viewportSize)) {
-        stableViewportFramesRef.current = 0;
-        scheduleAlignment();
-        return;
-      }
-
-      const previousSize = previousViewportSizeRef.current;
-      const sizeIsStable =
-        previousSize?.width === viewportSize.width &&
-        previousSize?.height === viewportSize.height;
-      stableViewportFramesRef.current = sizeIsStable
-        ? stableViewportFramesRef.current + 1
-        : 0;
-      previousViewportSizeRef.current = viewportSize;
-
-      const scroll = computeInitialScrollForRoot(
-        rootPoint,
-        rootSize,
-        viewportSize,
-        zoom,
-      );
-      viewport.scrollLeft = scroll.x;
-      viewport.scrollTop = scroll.y;
-
-      if (stableViewportFramesRef.current >= REQUIRED_STABLE_VIEWPORT_FRAMES) {
-        initialViewPositionedRef.current = true;
-        return;
-      }
-      scheduleAlignment();
-    };
-
-    const resizeObserver = new ResizeObserver(() => {
-      if (initialViewPositionedRef.current) return;
-      stableViewportFramesRef.current = 0;
-      previousViewportSizeRef.current = null;
-      scheduleAlignment();
-    });
-    resizeObserver.observe(viewport);
-    scheduleAlignment();
-
-    return () => {
-      disposed = true;
-      resizeObserver.disconnect();
-      if (initialCenterFrameRef.current !== null) {
-        cancelAnimationFrame(initialCenterFrameRef.current);
-        initialCenterFrameRef.current = null;
-      }
-    };
+    const scroll = computeInitialScrollForRoot(
+      rootPoint,
+      rootSize,
+      viewportSize,
+      zoom,
+    );
+    viewport.scrollLeft = scroll.x;
+    viewport.scrollTop = scroll.y;
+    initialViewPositionedRef.current = true;
   }, [
-    doc.cursorId,
-    doc.rootId,
-    layout.positions,
-    layout.sizes,
+    rootPoint?.x,
+    rootPoint?.y,
+    rootSize?.height,
+    rootSize?.width,
     viewSessionKey,
     viewportRef,
     zoom,
@@ -263,8 +205,13 @@ export function EditorView({
   }, [disabled, mode, doc.cursorId]);
 
   useEffect(() => {
-    if (doc.cursorId === initialCursorIdRef.current) return;
-    initialCursorIdRef.current = null;
+    const shouldFollow = shouldFollowCursor(
+      initialViewPositionedRef.current,
+      previousCursorIdRef.current,
+      doc.cursorId,
+    );
+    previousCursorIdRef.current = doc.cursorId;
+    if (!shouldFollow) return;
     const root = canvasRef.current;
     if (!root) return;
     const el = root.querySelector<HTMLElement>(`[data-node-id="${doc.cursorId}"]`);

--- a/src/editor/domain/viewport.ts
+++ b/src/editor/domain/viewport.ts
@@ -22,6 +22,18 @@ export function shouldResetViewportSession(
   return previousSessionKey !== null && previousSessionKey !== nextSessionKey;
 }
 
+export function shouldFollowCursor(
+  initialViewPositioned: boolean,
+  previousCursorId: string | null,
+  nextCursorId: string,
+): boolean {
+  return (
+    initialViewPositioned &&
+    previousCursorId !== null &&
+    previousCursorId !== nextCursorId
+  );
+}
+
 export function computeCenteredScrollFromRects(
   currentScroll: CanvasPoint,
   targetRect: Rect,

--- a/tests/offline/viewport.test.cjs
+++ b/tests/offline/viewport.test.cjs
@@ -4,6 +4,7 @@ const {
   computeCenteredScrollFromRects,
   computeInitialScrollForRoot,
   isUsableViewportSize,
+  shouldFollowCursor,
   shouldResetViewportSession,
 } = require("../../.tmp-tests/src/editor/domain/viewport.js");
 
@@ -21,6 +22,17 @@ test("isUsableViewportSize waits for a measurable viewport", () => {
   assert.equal(isUsableViewportSize({ width: 0, height: 600 }), false);
   assert.equal(isUsableViewportSize({ width: 800, height: 0 }), false);
   assert.equal(isUsableViewportSize({ width: 800, height: 600 }), true);
+});
+
+test("shouldFollowCursor ignores initial observation and initial positioning", () => {
+  assert.equal(shouldFollowCursor(false, null, "root"), false);
+  assert.equal(shouldFollowCursor(false, "root", "child"), false);
+  assert.equal(shouldFollowCursor(true, null, "root"), false);
+});
+
+test("shouldFollowCursor follows only a cursor change after initial positioning", () => {
+  assert.equal(shouldFollowCursor(true, "root", "root"), false);
+  assert.equal(shouldFollowCursor(true, "root", "child"), true);
 });
 
 test("computeCenteredScrollFromRects centers the rendered target", () => {


### PR DESCRIPTION
## 概要 / Summary
アプリ起動時にノードが右下へ表示される問題を修正しました。
The root node is now positioned at the left center when opening a document.

## 変更内容 / Changes
- `viewportRef` 確定後に初期スクロール位置を設定
- ルートノードを左余白48px、縦中央へ配置
- 初期表示時のカーソル追従による位置上書きを抑止
- 文書切り替え後も初期位置を再計算
- 関連するユニットテストを追加

## 検証 / Verification
- `npm run test:offline`: 103 tests passed
- `npm run build`: passed
- ブラウザで左余白48px、縦中央への配置を確認